### PR TITLE
Fabo/fix bad asset location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- fix bad asset location @faboweb
+
 ## [0.2.19]
 
 - Adjust TmLiTransaction to the new transaction format @faboweb @jbibla

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.2.20]
+
 - fix bad asset location @faboweb
 
 ## [0.2.19]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@tendermint/ui",
   "productName": "Tendermint UI",
   "description": "Tendermint UI contains components for front end projects.",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "license": "Apache-2.0",
   "author": "Tendermint, Inc <hello@tendermint.com>",
   "main": "src/index.js",

--- a/src/components/TmLiTransaction/TmLiTransaction.vue
+++ b/src/components/TmLiTransaction/TmLiTransaction.vue
@@ -1,7 +1,7 @@
 <template lang='pug'>
 .tm-li-tx
   .tm-li-tx__icon
-    img(src="~assets/cosmos-logo.png" :style="{ borderColor: color }")
+    img(src="../../assets/cosmos-logo.png" :style="{ borderColor: color }")
   .tm-li-tx__content
     p.tm-li-tx__content__caption
       slot(name="caption")
@@ -39,9 +39,8 @@ export default {
   border 1px solid var(--bc-dim)
   background var(--app-fg)
 
-  &:hover {
+  &:hover
     background var(--hover-bg)
-  }
 
   b
     font-weight 500
@@ -51,7 +50,7 @@ export default {
 
     img
       max-height 100%
-      max-width: 52px;
+      max-width 52px
       border 2px solid
       border-radius 50%
       display block

--- a/tests/unit/__snapshots__/TmBlock.spec.js.snap
+++ b/tests/unit/__snapshots__/TmBlock.spec.js.snap
@@ -274,7 +274,7 @@ exports[`TmBlock.vue has the expected html structure 1`] = `
       <main class="tm-part-main">
         <div class="tm-li-tx">
           <div class="tm-li-tx__icon">
-            <img src="~assets/cosmos-logo.png" style="border-color: #25293f;">
+            <img src="../../assets/cosmos-logo.png" style="border-color: #25293f;">
           </div>
           <div class="tm-li-tx__content">
             <p class="tm-li-tx__content__caption">
@@ -295,7 +295,7 @@ exports[`TmBlock.vue has the expected html structure 1`] = `
         </div>
         <div class="tm-li-tx">
           <div class="tm-li-tx__icon">
-            <img src="~assets/cosmos-logo.png" style="border-color: #215c2f;">
+            <img src="../../assets/cosmos-logo.png" style="border-color: #215c2f;">
           </div>
           <div class="tm-li-tx__content">
             <p class="tm-li-tx__content__caption">
@@ -316,7 +316,7 @@ exports[`TmBlock.vue has the expected html structure 1`] = `
         </div>
         <div class="tm-li-tx">
           <div class="tm-li-tx__icon">
-            <img src="~assets/cosmos-logo.png" style="border-color: #25293f;">
+            <img src="../../assets/cosmos-logo.png" style="border-color: #25293f;">
           </div>
           <div class="tm-li-tx__content">
             <p class="tm-li-tx__content__caption">
@@ -337,7 +337,7 @@ exports[`TmBlock.vue has the expected html structure 1`] = `
         </div>
         <div class="tm-li-tx">
           <div class="tm-li-tx__icon">
-            <img src="~assets/cosmos-logo.png" style="border-color: #512584;">
+            <img src="../../assets/cosmos-logo.png" style="border-color: #512584;">
           </div>
           <div class="tm-li-tx__content">
             <p class="tm-li-tx__content__caption">
@@ -361,7 +361,7 @@ exports[`TmBlock.vue has the expected html structure 1`] = `
         </div>
         <div class="tm-li-tx">
           <div class="tm-li-tx__icon">
-            <img src="~assets/cosmos-logo.png">
+            <img src="../../assets/cosmos-logo.png">
           </div>
           <div class="tm-li-tx__content">
             <p class="tm-li-tx__content__caption">

--- a/tests/unit/__snapshots__/TmLiAnyTransaction.spec.js.snap
+++ b/tests/unit/__snapshots__/TmLiAnyTransaction.spec.js.snap
@@ -8,7 +8,7 @@ exports[`TmLiAnyTransaction shows bank transactions 1`] = `
     class="tm-li-tx__icon"
   >
     <img
-      src="~assets/cosmos-logo.png"
+      src="../../assets/cosmos-logo.png"
       style="border-color: #25293f;"
     />
   </div>
@@ -61,7 +61,7 @@ exports[`TmLiAnyTransaction shows stake transactions 1`] = `
     class="tm-li-tx__icon"
   >
     <img
-      src="~assets/cosmos-logo.png"
+      src="../../assets/cosmos-logo.png"
       style="border-color: #512584;"
     />
   </div>
@@ -119,7 +119,7 @@ exports[`TmLiAnyTransaction shows unknown transactions 1`] = `
     class="tm-li-tx__icon"
   >
     <img
-      src="~assets/cosmos-logo.png"
+      src="../../assets/cosmos-logo.png"
     />
   </div>
   <div

--- a/tests/unit/__snapshots__/TmLiStakeTransaction.spec.js.snap
+++ b/tests/unit/__snapshots__/TmLiStakeTransaction.spec.js.snap
@@ -8,7 +8,7 @@ exports[`TmLiStakeTransaction should show delegations 1`] = `
     class="tm-li-tx__icon"
   >
     <img
-      src="~assets/cosmos-logo.png"
+      src="../../assets/cosmos-logo.png"
       style="border-color: #512584;"
     />
   </div>
@@ -66,7 +66,7 @@ exports[`TmLiStakeTransaction should show unbondings 1`] = `
     class="tm-li-tx__icon"
   >
     <img
-      src="~assets/cosmos-logo.png"
+      src="../../assets/cosmos-logo.png"
       style="border-color: #9d5c19;"
     />
   </div>

--- a/tests/unit/__snapshots__/TmLiTransaction.spec.js.snap
+++ b/tests/unit/__snapshots__/TmLiTransaction.spec.js.snap
@@ -8,7 +8,7 @@ exports[`TmLiTransaction has the expected html structure 1`] = `
     class="tm-li-tx__icon"
   >
     <img
-      src="~assets/cosmos-logo.png"
+      src="../../assets/cosmos-logo.png"
       style="border-color: #ffffff;"
     />
   </div>


### PR DESCRIPTION
Using `~assets/...` doesn't work when using this library in another context, as this path will get resolved in the context of the importing project. We need to use the relative path syntax for assets inside this library.