### PR TITLE
Modal: overlay and button props

### DIFF
--- a/src/Modal/Modal.vue
+++ b/src/Modal/Modal.vue
@@ -2,13 +2,13 @@
   <div>
     <div class="wrapper" v-if="visible">
       <transition name="overlay" @after-leave="close" appear>
-        <div class="overlay" v-if="visible && show"></div>
+        <div class="overlay" v-if="visible && show" :style="{'--overlay-background': overlay}"></div>
       </transition>
       <div class="modal-wrapper" @click.self="show = false" @keydown.esc="close">
         <transition name="modal" appear>
           <div class="modal" v-if="visible && show">
-            <button class="icon-cross" @click="show = false">
-              <svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 4l16 16m0-16L4 20" stroke="#A2A3AD" stroke-width="1.5" stroke-linecap="round"/></svg>
+            <button :class="['icon-cross', {'icon-cross__dark': button == 'dark'}]" @click="show = false">
+              <svg width="24" height="24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 4l16 16m0-16L4 20" stroke-width="1.5" stroke-linecap="round"/></svg>
             </button>
             <slot></slot>
           </div>
@@ -20,7 +20,20 @@
 
 <script>
 export default {
-  props: ["visible"],
+  props: {
+    visible: {
+      type: Boolean,
+      default: true
+    },
+    overlay: {
+      type: String,
+      default: "rgba(0, 0, 0, 0.25)"
+    },
+    button: {
+      type: String,
+      default: "light"
+    }
+  },
   data: function() {
     return {
       show: true
@@ -47,7 +60,7 @@ export default {
 }
 
 .overlay {
-  background: rgba(0, 0, 0, 0.25);
+  background: var(--overlay-background);
   position: fixed;
   top: 0;
   left: 0;
@@ -64,14 +77,12 @@ export default {
   height: 100%;
   position: relative;
   overflow-x: hidden;
-  padding-left: 2rem;
-  padding-right: 2rem;
+  padding-right: 4rem;
+  padding-left: 4rem;
 }
 
 .modal {
   justify-self: center;
-  width: 100%;
-  max-width: 960px;
   background: #fff;
   border-radius: 8px;
   position: relative;
@@ -100,7 +111,25 @@ export default {
   cursor: pointer;
   z-index: 1000;
   transition: box-shadow 0.3s, background 0.3s;
+  stroke: #a2a3ad;
 }
+
+.icon-cross.icon-cross__dark {
+  background: #222;
+  box-shadow: 0px 12px 48px rgba(0, 0, 0, 0.75);
+  border: none;
+  stroke: #555;
+}
+
+.icon-cross.icon-cross__dark:hover,
+.icon-cross.icon-cross__dark:focus {
+  background: #333;
+  box-shadow: none;
+  box-shadow: 0px 12px 48px rgba(0, 0, 0, 0.75);
+  border: none;
+  stroke: #777;
+}
+
 .icon-cross:hover,
 .icon-cross:focus {
   background-color: #fff;

--- a/src/Modal/Modal.vue
+++ b/src/Modal/Modal.vue
@@ -2,9 +2,9 @@
   <div>
     <div class="wrapper" v-if="visible">
       <transition name="overlay" @after-leave="close" appear>
-        <div class="overlay" @click.self="show = false" @keydown.esc="close" v-if="visible && show"></div>
+        <div class="overlay" v-if="visible && show"></div>
       </transition>
-      <div class="modal-wrapper">
+      <div class="modal-wrapper" @click.self="show = false" @keydown.esc="close">
         <transition name="modal" appear>
           <div class="modal" v-if="visible && show">
             <button class="icon-cross" @click="show = false">
@@ -46,12 +46,6 @@ export default {
   overflow: scroll;
 }
 
-.modal-wrapper {
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-}
-
 .overlay {
   background: rgba(0, 0, 0, 0.25);
   position: fixed;
@@ -62,17 +56,31 @@ export default {
   pointer-events: all;
 }
 
+.modal-wrapper {
+  display: grid;
+  justify-content: center;
+  align-items: center;
+  grid-template-columns: 1fr;
+  height: 100%;
+  position: relative;
+  overflow-x: hidden;
+  padding-left: 2rem;
+  padding-right: 2rem;
+}
+
 .modal {
+  justify-self: center;
   width: 100%;
   max-width: 960px;
   background: #fff;
   border-radius: 8px;
   position: relative;
+  pointer-events: all;
   margin-top: 4rem;
   margin-bottom: 4rem;
-  pointer-events: all;
   box-shadow: 0 5px 30px 0 rgba(0, 0, 0, 0.2);
 }
+
 .icon-cross {
   position: absolute;
   right: -1.5rem;
@@ -177,6 +185,12 @@ export default {
     margin: 0;
     border-radius: 0;
     min-height: 100vh;
+  }
+
+  .modal-wrapper {
+    display: block;
+    padding-left: 0;
+    padding-right: 0;
   }
   .container {
     display: block;


### PR DESCRIPTION
Added `overlay` (string, used as color) and `button` (string, `"dark"` makes the button, well, dark). Decided against passing CSS vars, because they may be by mistake overwritten. You can never be sure that your `--overlay-background` won't be set to something like `red` by some random component. Also, modal should center properly and respect `max-width` of it's content.

<img width="1452" alt="Screenshot 2019-10-17 at 13 43 01" src="https://user-images.githubusercontent.com/332151/66993124-8076f480-f0e4-11e9-9206-cfe3ba229d1a.png">
