### PR TITLE
Tooltip: reposition based on viewport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmos-ui/vue",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmos-ui/vue",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmos-ui/vue",
-  "version": "0.5.8",
+  "version": "0.5.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@cosmos-ui/vue",
   "productName": "Tendermint UI",
   "description": "Tendermint UI contains components for front end projects.",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "license": "Apache-2.0",
   "main": "src/index.js",
   "author": "Tendermint, Inc <hello@tendermint.com>",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@cosmos-ui/vue",
   "productName": "Tendermint UI",
   "description": "Tendermint UI contains components for front end projects.",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "license": "Apache-2.0",
   "main": "src/index.js",
   "author": "Tendermint, Inc <hello@tendermint.com>",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@cosmos-ui/vue",
   "productName": "Tendermint UI",
   "description": "Tendermint UI contains components for front end projects.",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "license": "Apache-2.0",
   "main": "src/index.js",
   "author": "Tendermint, Inc <hello@tendermint.com>",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@cosmos-ui/vue",
   "productName": "Tendermint UI",
   "description": "Tendermint UI contains components for front end projects.",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "license": "Apache-2.0",
   "main": "src/index.js",
   "author": "Tendermint, Inc <hello@tendermint.com>",

--- a/src/Tooltip/Tooltip.vue
+++ b/src/Tooltip/Tooltip.vue
@@ -1,9 +1,9 @@
 <template>
-  <div style="display: inline-block; position: relative;">
-    <button class="term" tabindex="0" @click="select">
+  <div style="display: inline-block; position: relative;" ref="container">
+    <button class="term" tabindex="0" @click="select" ref="term">
       <slot></slot>
     </button>
-    <div class="tooltip" ref="tooltip" tabindex="1" v-html="definition"></div>
+    <div class="tooltip" ref="tooltip" :style="[...getPosition]" tabindex="1" v-html="definition" @focus="setPosition($event)"></div>
   </div>
 </template>
 
@@ -27,7 +27,6 @@ button {
 .tooltip {
   min-width: 300px;
   position: absolute;
-  left: 0;
   background: white;
   font-size: 0.75rem;
   line-height: 1.5;
@@ -39,6 +38,8 @@ button {
   outline: none;
   transition: all 0.1s ease-in;
   transform: translateY(-1em);
+  z-index: 1000000;
+  box-sizing: border-box;
 }
 
 .tooltip:focus {
@@ -58,14 +59,37 @@ export default {
       type: String
     }
   },
+  data: function() {
+    return {
+      left: true
+    };
+  },
+  mounted() {
+    window.addEventListener("resize", this.setPosition);
+    this.setPosition();
+  },
   computed: {
     definition() {
       return new MarkdownIt().render(dict[this.value]);
+    },
+    getPosition() {
+      return {
+        left: this.left ? 0 : "initial",
+        right: !this.left ? 0 : "initial"
+      };
     }
   },
   methods: {
     select() {
       this.$refs.tooltip.focus();
+    },
+    setPosition(e) {
+      const screenWidth = Math.max(
+        document.documentElement.clientWidth,
+        window.innerWidth || 0
+      );
+      const elementX = this.$refs.container.getBoundingClientRect().left;
+      this.left = !(elementX + 300 > screenWidth);
     }
   }
 };


### PR DESCRIPTION
Right now tooltip is displayed left-aligned to the term-word. If term is too close to the viewport's right border, the tooltip either gets clipped (if there the overflow is hidden) or makes the parent wider than the viewport (with a horizontal scrollbar).

This repositions the tooltip based on relative proximity to viewport edge.

<img width="675" alt="Screenshot 2019-10-20 at 20 16 56" src="https://user-images.githubusercontent.com/332151/67161722-9d2a5b00-f376-11e9-9df9-6595cda9aa40.png">

<img width="612" alt="Screenshot 2019-10-20 at 20 17 02" src="https://user-images.githubusercontent.com/332151/67161724-9f8cb500-f376-11e9-8f0b-68d7b8e96954.png">

close #101 