### PR TITLE
Responsive tooltips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cosmos-ui/vue",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@cosmos-ui/vue",
   "productName": "Tendermint UI",
   "description": "Tendermint UI contains components for front end projects.",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "license": "Apache-2.0",
   "main": "src/index.js",
   "author": "Tendermint, Inc <hello@tendermint.com>",


### PR DESCRIPTION
Addressing comments in https://github.com/cosmos/cosmos.network/pull/624

<img width="612" alt="Screenshot 2019-10-27 at 00 18 44" src="https://user-images.githubusercontent.com/332151/67624868-15e65700-f850-11e9-9f0c-4a5ef64c5f8b.png">

<img width="873" alt="Screenshot 2019-10-27 at 00 20 19" src="https://user-images.githubusercontent.com/332151/67624870-1b43a180-f850-11e9-9011-d9270293fbf7.png">

By default the tooltip aligns to the left of the term-word. If the space to the right is not enough to fit the tooltip, it switches to right-align and sticks to the right edge of the screen. When the viewport becomes narrow, it calculates left and right position to use full 100vw. It's positioned absolutely relative to the term-word, so coordinates must be calculated rather then using `fixed` and `left: 0`.

Tested in Chrome, FF, Safari and Chrome on Android.